### PR TITLE
avoid unnecessary memory allocation in HttpURLConnection

### DIFF
--- a/jdk/src/share/classes/sun/net/www/protocol/http/HttpURLConnection.java
+++ b/jdk/src/share/classes/sun/net/www/protocol/http/HttpURLConnection.java
@@ -1836,7 +1836,10 @@ public class HttpURLConnection extends java.net.HttpURLConnection {
                 }
 
                 try {
-                    cl = Long.parseLong(responses.findValue("content-length"));
+                	String contentLength = responses.findValue("content-length");
+                	if (contentLength != null) {
+                		cl = Long.parseLong(contentLength);
+                	}
                 } catch (Exception exc) { };
 
                 if (method.equals("HEAD") || cl == 0 ||


### PR DESCRIPTION
check the context-length (may be null in chunked encoding) before invoke Long.parseLong to avoid a large amount of gabage in a bunch of http call.

jdk/src/share/classes/sun/net/www/protocol/http/HttpURLConnection.java